### PR TITLE
Ensure that auth is sorted.

### DIFF
--- a/TileStache/Caches.py
+++ b/TileStache/Caches.py
@@ -200,7 +200,7 @@ class Disk:
         e = format.lower()
         e += self._is_compressed(format) and '.gz' or ''
         if auth:
-            auth_part = os.sep.join([str(i) for i in auth])
+            auth_part = os.sep.join(sorted(str(i) for i in auth))
         else:
             auth_part = ''
         

--- a/TileStache/Memcache.py
+++ b/TileStache/Memcache.py
@@ -45,7 +45,7 @@ def tile_key(layer, coord, auth, format, rev, key_prefix):
     name = layer.name()
     tile = '%(zoom)d/%(column)d/%(row)d' % coord.__dict__
     if auth:
-        ids = "/".join(str(id) for id in auth)
+        ids = "/".join(str(id) for id in sorted(auth))
         return str('%(key_prefix)s/%(rev)s/%(name)s/%(tile)s/%(ids)s.%(format)s' % locals())
     else:
         return str('%(key_prefix)s/%(rev)s/%(name)s/%(tile)s.%(format)s' % locals())

--- a/TileStache/Redis.py
+++ b/TileStache/Redis.py
@@ -55,7 +55,7 @@ def tile_key(layer, coord, auth, format, key_prefix):
     name = layer.name()
     tile = '%(zoom)d/%(column)d/%(row)d' % coord.__dict__
     if auth:
-        ids = "/".join(str(id) for id in auth)
+        ids = "/".join(str(id) for id in sorted(auth))
         key = str('%(key_prefix)s/%(name)s/%(tile)s/%(ids)s.%(format)s' % locals())
     else:
         key = str('%(key_prefix)s/%(name)s/%(tile)s.%(format)s' % locals())


### PR DESCRIPTION
Defensive programming: make sure auth is sorted. A different ordering should not result in new tiles.
